### PR TITLE
Adding network dependencies [Delivers 183848506]

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,5 +37,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'com.github.ittianyu:BottomNavigationViewEx:2.0.2'
+    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
 
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,14 +2,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.newswatchtower5">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
+        android:fullBackupContent="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme"
-        android:fullBackupContent="true">
+        android:theme="@style/AppTheme">
         <activity
             android:name=".NewsActivity"
             android:label="@string/app_name"
@@ -17,6 +19,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/163848506

**Overview**
In order to consume the api, we need dependencies that support networking hence retrofit and giving the application internet permissions.

**Background**
NONE

**Acceptance Criteria**
- The application should operate as before.

**How to manually test**
- Clone the repository
- Checkout to the ch-network-dependencies-183848506
- Check the Android.Manifest file and the dependencies file for internet permissions and retrofit dependencies respectively.

**Story**
[#183848506]

