### PR TITLE
News reports show respective images [Delivers #163939746]

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,5 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
-
-
+    implementation 'com.squareup.picasso:picasso:2.5.2'
 }

--- a/app/src/main/java/com/example/newswatchtower5/adapters/NewsAdapter.kt
+++ b/app/src/main/java/com/example/newswatchtower5/adapters/NewsAdapter.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.example.newswatchtower5.R
 import com.example.newswatchtower5.models.Article
 import com.example.newswatchtower5.shared.shareStory
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.squareup.picasso.Picasso
 
 class NewsAdapter(context: Context, private val newsUpdates: List<Article>) :
     RecyclerView.Adapter<NewsAdapter.ViewHolder>() {
@@ -33,10 +35,11 @@ class NewsAdapter(context: Context, private val newsUpdates: List<Article>) :
 
 
         }
+        Picasso.with(holder.itemView.context).load(newsUpdate.urlToImage).into(holder.imageView)
     }
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        //        var imageUrl = itemView.findViewById<ImageView>(R.id.newsImage)
+        var imageView = itemView.findViewById<ImageView>(R.id.newsImage)
         var title = itemView.findViewById<TextView>(R.id.headlineTextView)
         var description = itemView.findViewById<TextView>(R.id.descriptionTextView)
         var shareButton =

--- a/app/src/main/res/layout/single_news_item.xml
+++ b/app/src/main/res/layout/single_news_item.xml
@@ -22,7 +22,7 @@
                 android:contentDescription="@string/news_image_description"
                 android:id="@+id/newsImage"
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
+                android:layout_height="200dp"
                 android:layout_marginStart="8dp"
                 android:layout_marginTop="16dp"
                 android:layout_marginEnd="8dp"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/163939746
**Overview**
This PR provides the user with the ability to view respective images for the news reports

**Background**
NONE

**Acceptance Criteria**
- The application should operate as before.
- A user should view images of news reports.

**How to manually test**
- Clone the repository
- Checkout to the ft-implement-news-images-163939746
- Run ./gradlew build.
- Run the application on either an emulator or device.
- Observe the news reports.

**Screenshots**
<img width="285" alt="screenshot 2019-02-13 at 14 20 20" src="https://user-images.githubusercontent.com/17830204/52708362-fa297200-2f9a-11e9-9f5c-2aa3f8793e4a.png">


**Story**
[ #163939746]

