### PR TITLE
detail view for news [Delivers #163959072]

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,9 @@ android {
     buildTypes.each {
         it.buildConfigField 'String', 'ApiSecKey', ApiKey
     }
+    androidExtensions {
+        experimental = true
+    }
 
 }
 

--- a/app/src/main/java/com/example/newswatchtower5/NewsActivity.kt
+++ b/app/src/main/java/com/example/newswatchtower5/NewsActivity.kt
@@ -8,18 +8,26 @@ import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.GravityCompat
 import androidx.fragment.app.Fragment
+import com.example.newswatchtower5.constants.NEWS_DETAILS
 import com.example.newswatchtower5.helpers.HelperInterface
 import com.example.newswatchtower5.internationalnews.InternationalNewsFragment
-import com.example.newswatchtower5.shared.GeneralFragment
-import com.example.newswatchtower5.shared.exitCount
-import com.example.newswatchtower5.shared.loadFragment
-import com.example.newswatchtower5.shared.setFragmentVisibility
+import com.example.newswatchtower5.models.Article
+import com.example.newswatchtower5.shared.*
 import com.google.android.material.navigation.NavigationView
 import kotlinx.android.synthetic.main.activity_news.*
 import kotlinx.android.synthetic.main.app_bar_news.*
 
 class NewsActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener,
     HelperInterface {
+    override fun loadDetailView(article: Article) {
+        val detailFragment = DetailFragment()
+        val bundle = Bundle()
+        bundle.putParcelable(NEWS_DETAILS, article)
+        detailFragment.arguments = bundle
+        val fragment = HashMap<String, Fragment>()
+        fragment[getString(R.string.detailFragment)] = detailFragment
+        loadFragment(supportFragmentManager, findViewById(R.id.frame), fragment)
+    }
 
 
     override fun loadDefaultFragment() {

--- a/app/src/main/java/com/example/newswatchtower5/adapters/NewsAdapter.kt
+++ b/app/src/main/java/com/example/newswatchtower5/adapters/NewsAdapter.kt
@@ -8,6 +8,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.example.newswatchtower5.R
+import com.example.newswatchtower5.helpers.HelperInterface
 import com.example.newswatchtower5.models.Article
 import com.example.newswatchtower5.shared.shareStory
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -24,7 +25,6 @@ class NewsAdapter(context: Context, private val newsUpdates: List<Article>) :
 
     override fun onBindViewHolder(holder: NewsAdapter.ViewHolder, position: Int) {
         val newsUpdate = newsUpdates[position]
-//      holder.imageUrl.setImageDrawable() = newsUpdate.urlToImage
         holder.title.text = newsUpdate.title
         holder.description.text = newsUpdate.description
         holder.shareButton.setOnClickListener {
@@ -36,6 +36,11 @@ class NewsAdapter(context: Context, private val newsUpdates: List<Article>) :
 
         }
         Picasso.with(holder.itemView.context).load(newsUpdate.urlToImage).into(holder.imageView)
+
+        holder.itemView.setOnClickListener {
+            val helperInterface = holder.itemView.context as HelperInterface
+            helperInterface.loadDetailView(newsUpdate)
+        }
     }
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/app/src/main/java/com/example/newswatchtower5/constants/constants.kt
+++ b/app/src/main/java/com/example/newswatchtower5/constants/constants.kt
@@ -5,3 +5,4 @@ const val KIGALI_NEWS = 1
 const val LAGOS_NEWS = 2
 const val NAIROBI_NEWS = 3
 const val NEW_YORK_NEWS = 4
+const val NEWS_DETAILS = "com.example.newswatchtower5.NEWS_DETAILS"

--- a/app/src/main/java/com/example/newswatchtower5/helpers/HelperInterface.kt
+++ b/app/src/main/java/com/example/newswatchtower5/helpers/HelperInterface.kt
@@ -1,6 +1,10 @@
 package com.example.newswatchtower5.helpers
 
+import com.example.newswatchtower5.models.Article
+
 interface HelperInterface {
     fun loadDefaultFragment()
+
+    fun loadDetailView(article: Article)
 }
 

--- a/app/src/main/java/com/example/newswatchtower5/models/NewsReport.kt
+++ b/app/src/main/java/com/example/newswatchtower5/models/NewsReport.kt
@@ -1,6 +1,8 @@
 package com.example.newswatchtower5.models
 
+import android.os.Parcelable
 import androidx.fragment.app.Fragment
+import kotlinx.android.parcel.Parcelize
 
 /**
  * 3 classes responsible for how our requests are represented.
@@ -11,7 +13,8 @@ data class NewsReport(
     val articles: List<Article>
 )
 
-data class Article(
+@Parcelize
+class Article(
     val source: Source,
     val author: String? = null,
     val title: String,
@@ -20,12 +23,13 @@ data class Article(
     val urlToImage: String,
     val publishedAt: String,
     val content: String? = null
-)
+) : Parcelable
 
+@Parcelize
 data class Source(
     val id: String? = null,
     val name: String
-)
+) : Parcelable
 
 /**
  * Responsible for keep track of our fragments

--- a/app/src/main/java/com/example/newswatchtower5/shared/DetailFragment.kt
+++ b/app/src/main/java/com/example/newswatchtower5/shared/DetailFragment.kt
@@ -1,0 +1,66 @@
+package com.example.newswatchtower5.shared
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import com.example.newswatchtower5.R
+import com.example.newswatchtower5.constants.NEWS_DETAILS
+import com.example.newswatchtower5.helpers.HelperInterface
+import com.example.newswatchtower5.models.Article
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.squareup.picasso.Picasso
+import java.text.SimpleDateFormat
+import java.util.*
+
+class DetailFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view: View = inflater.inflate(R.layout.fragment_news_details, container, false)
+
+        val article = this.arguments!![NEWS_DETAILS] as Article
+
+        val homeButton = view.findViewById<ImageButton>(R.id.home_button)
+        val shareButton = view.findViewById<FloatingActionButton>(R.id.floatingActionShareButton)
+        val newsImage = view.findViewById<ImageView>(R.id.newsImage)
+        val headlineTextView = view.findViewById<TextView>(R.id.headlineTextView)
+        val descriptionTextView = view.findViewById<TextView>(R.id.descriptionTextView)
+        val publishDateTextView = view.findViewById<TextView>(R.id.publishDateTextView)
+        val sourceTextView = view.findViewById<TextView>(R.id.sourceTextView)
+        val authorTextView = view.findViewById<TextView>(R.id.authorTextView)
+        val sourceUrlTextView = view.findViewById<TextView>(R.id.sourceUrlTextView)
+
+        Picasso.with(view.context).load(article.urlToImage).into(newsImage)
+        val simpleDateFormat = SimpleDateFormat("d-MM-Y", Locale.US)
+        val date = simpleDateFormat.parse(article.publishedAt.substring(0, 10))
+        headlineTextView.text = article.title
+        descriptionTextView.text = article.description
+        publishDateTextView.text = simpleDateFormat.format(date).replace('-', '/')
+        sourceTextView.text = article.source.name
+        authorTextView.text = article.author
+        sourceUrlTextView.text = article.url
+
+        homeButton.setOnClickListener {
+            val helperInterface = activity as HelperInterface
+            helperInterface.loadDefaultFragment()
+        }
+
+        shareButton.setOnClickListener {
+            val message =
+                "Title:\t" + article.title + "\n" + "\nDescription:\t" + article.description + "\n" + "\nLink:\t" + article.url +
+                        "\n" + "\nSource:\t" + article.source.name + "\n"
+            shareStory(view.context, message, view.context.packageManager)
+        }
+
+
+        return view
+    }
+}

--- a/app/src/main/res/layout/fragment_news_details.xml
+++ b/app/src/main/res/layout/fragment_news_details.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginTop="?attr/actionBarSize">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:text="@string/news_details"
+        android:textAlignment="center"
+        android:textAppearance="@android:style/TextAppearance.Material.Large"
+        android:textColor="@android:color/darker_gray"
+        android:textSize="30sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@+id/home_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/home_button"
+        app:layout_constraintTop_toTopOf="@+id/home_button" />
+
+    <ImageButton
+        android:id="@+id/home_button"
+        style="@android:style/Widget.Material.ImageButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:backgroundTint="@color/white"
+        android:contentDescription="@string/home_button"
+        android:elevation="16dp"
+        android:tint="@color/colorPrimary"
+        app:layout_constraintEnd_toStartOf="@+id/title"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_home_black_24dp" />
+
+    <include
+        layout="@layout/include_news_detail_card"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/home_button" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/include_news_detail_card.xml
+++ b/app/src/main/res/layout/include_news_detail_card.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    app:cardCornerRadius="4dp"
+    app:cardElevation="4dp"
+    app:cardPreventCornerOverlap="false"
+    app:cardUseCompatPadding="true"
+    app:contentPadding="16dp">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <include layout="@layout/include_news_detail_structure" />
+    </ScrollView>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/include_news_detail_structure.xml
+++ b/app/src/main/res/layout/include_news_detail_structure.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TableLayout
+        android:id="@+id/tableLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:paddingEnd="4dp"
+        android:paddingStart="0dp"
+        android:stretchColumns="2"
+        app:layout_constraintEnd_toEndOf="@+id/descriptionTextView"
+        app:layout_constraintStart_toStartOf="@+id/descriptionTextView"
+        app:layout_constraintTop_toBottomOf="@+id/descriptionTextView">
+
+        <TableRow
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_column="1"
+                android:text="@string/publish_date"
+                android:textAppearance="@android:style/TextAppearance.Material.Medium"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/publishDateTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_column="2"
+                android:textAlignment="center"
+                android:textAppearance="@android:style/TextAppearance.Material.Medium"
+                android:textSize="14sp"
+                tools:text="Jan 01 1991" />
+        </TableRow>
+
+        <TableRow
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_column="1"
+                android:text="@string/source"
+                android:textAppearance="@android:style/TextAppearance.Material.Medium"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/sourceTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_column="2"
+                android:textAlignment="center"
+                android:textAppearance="@android:style/TextAppearance.Material.Medium"
+                android:textSize="14sp"
+                tools:text="BBC"
+                android:scrollHorizontally="true"
+                />
+        </TableRow>
+
+        <TableRow
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_column="1"
+                android:text="@string/author"
+                android:textAppearance="@android:style/TextAppearance.Material.Medium"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/authorTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_column="2"
+                android:textAlignment="center"
+                android:textAppearance="@android:style/TextAppearance.Material.Medium"
+                android:textSize="14sp"
+                tools:text="John Smith"
+                android:scrollHorizontally="true"
+                />
+        </TableRow>
+
+    </TableLayout>
+
+
+    <TextView
+        android:id="@+id/sourceUrlTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:textAlignment="center"
+        android:textAppearance="@android:style/TextAppearance.Material.Medium"
+        android:textColor="@color/design_default_color_primary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/tableLayout"
+        app:layout_constraintStart_toStartOf="@+id/tableLayout"
+        app:layout_constraintTop_toBottomOf="@+id/tableLayout"
+        tools:text="http://www.bbc-news.com/1"
+        android:autoLink="web"
+        />
+
+
+    <ImageView
+        android:id="@+id/newsImage"
+        android:layout_width="0dp"
+        android:layout_height="200dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="8dp"
+        android:contentDescription="@string/news_image_description"
+        android:scaleType="centerCrop"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/default_image" />
+
+    <TextView
+        android:id="@+id/headlineTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textAppearance="@android:style/TextAppearance.Material.Medium"
+        android:textColor="@color/colorPrimary"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="@+id/newsImage"
+        app:layout_constraintStart_toStartOf="@+id/newsImage"
+        app:layout_constraintTop_toBottomOf="@+id/newsImage"
+        tools:text="Sample title for news title that will" />
+
+    <TextView
+        android:id="@+id/descriptionTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textAppearance="@android:style/TextAppearance.Material.Medium"
+        app:layout_constraintEnd_toEndOf="@+id/headlineTextView"
+        app:layout_constraintHorizontal_bias="0.513"
+        app:layout_constraintStart_toStartOf="@+id/headlineTextView"
+        app:layout_constraintTop_toBottomOf="@+id/headlineTextView"
+        tools:text="Sample title for news title that will and this will display how text shows up on the news app" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/floatingActionSaveButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="8dp"
+        android:clickable="true"
+        android:focusable="true"
+        app:layout_constraintEnd_toEndOf="@+id/newsImage"
+        app:layout_constraintTop_toTopOf="@+id/newsImage"
+        app:srcCompat="@drawable/ic_save_black_24dp" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/floatingActionShareButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:clickable="true"
+        android:focusable="true"
+        app:layout_constraintBottom_toBottomOf="@+id/newsImage"
+        app:layout_constraintEnd_toEndOf="@+id/newsImage"
+        app:layout_constraintTop_toBottomOf="@+id/floatingActionSaveButton"
+        app:srcCompat="@drawable/ic_share_black_24dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/single_news_item.xml
+++ b/app/src/main/res/layout/single_news_item.xml
@@ -6,13 +6,15 @@
     android:layout_height="wrap_content">
 
     <androidx.cardview.widget.CardView
+        android:foreground="?android:attr/selectableItemBackground"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:cardCornerRadius="4dp"
         app:cardElevation="4dp"
         app:cardPreventCornerOverlap="false"
         app:cardUseCompatPadding="true"
-        app:contentPadding="16dp">
+        app:contentPadding="16dp"
+        android:focusable="true">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
@@ -53,7 +55,7 @@
                 android:layout_marginTop="8dp"
                 android:layout_marginBottom="8dp"
                 android:ellipsize="end"
-                android:minLines="2"
+                android:maxLines="2"
                 android:textAppearance="@android:style/TextAppearance.Material.Medium"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="@+id/headlineTextView"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,9 @@
     <string name="bbc">bbc-news</string>
     <string name="internationalFragment">internationalFragment</string>
     <string name="news_watchtower_5">News WatchTower 5</string>
+    <string name="news_details">News Details</string>
+    <string name="author">Author</string>
+    <string name="source">Source</string>
+    <string name="publish_date">Publish Date</string>
+    <string name="detailFragment">detailFragment</string>
 </resources>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/163959072

**Overview**
This PR provides improves the user experience by having them access the details of a news report.

**Background**
There is  a ***bug*** where the card keeps becoming darker so this needs to be fixed

**Acceptance Criteria**
- The application should operate as before.
- A user should be able to view the details of a news item from the list

**How to manually test**
- Clone the repository
- Checkout to the ft-news-detail-view-#63959072
- Run ./gradlew build.
- Run the application on either an emulator or device.
- Select any item in the list, details about the item should be provided

**Story**
[#163959072]

**Screenshot**
<img width="286" alt="screenshot 2019-02-16 at 13 31 42" src="https://user-images.githubusercontent.com/17830204/52898535-31dd2780-31f0-11e9-9516-ccafa3a004ce.png">
